### PR TITLE
graphana: needs the user to access the host volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@
 go get -u github.com/Tkanos/api_trace_metrics_demo
 cd $GOPATH/src/github.com/Tkanos/api_trace_metrics_demo/app
 make install
-make build
 make deploy
 ```
 
 ### Run
 ```bash
 cd $GOPATH/src/github.com/Tkanos/api_trace_metrics_demo
-docker-compose up
+UID=`id -u` docker-compose up
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
         environment:
             - GF_SECURITY_ADMIN_PASSWORD=foobar
             - GF_USERS_ALLOW_SIGN_UP=false
+        user: $UID
     zipkin_storage:
         image: openzipkin/zipkin-mysql
         container_name: mysql


### PR DESCRIPTION
grafana is using a user specifically for the volume. When we pass our user grafana don't have problems to write in the host folder.